### PR TITLE
[WIP]購入機能実装(pay.jp)

### DIFF
--- a/app/assets/javascripts/payjp.js
+++ b/app/assets/javascripts/payjp.js
@@ -1,0 +1,33 @@
+document.addEventListener(
+  "DOMContentLoaded", e => {
+    if (document.getElementById("token_submit") != null) { //token_submitというidがnullの場合、下記コードを実行しない
+      Payjp.setPublicKey("pk_test_ea7c444d7b76292abd8acf09"); //ここに公開鍵を直書き
+      let btn = document.getElementById("token_submit"); //IDがtoken_submitの場合に取得されます
+      btn.addEventListener("click", e => { //ボタンが押されたときに作動します
+        e.preventDefault(); //ボタンを一旦無効化します
+        let card = {
+          number: document.getElementById("card_number").value,
+          cvc: document.getElementById("cvc").value,
+          exp_month: document.getElementById("exp_month").value,
+          exp_year: document.getElementById("exp_year").value
+        }; //入力されたデータを取得します。
+        Payjp.createToken(card, (status, response) => {
+          if (status === 200) { //成功した場合
+            $("#card_number").removeAttr("name");
+            $("#cvc").removeAttr("name");
+            $("#exp_month").removeAttr("name");
+            $("#exp_year").removeAttr("name"); //データを自サーバにpostしないように削除
+            $("#card_token").append(
+              $('<input type="hidden" name="payjp-token">').val(response.id)
+            ); //取得したトークンを送信できる状態にします
+            document.inputForm.submit();
+            alert("登録が完了しました"); //確認用
+          } else {
+            alert("カード情報が正しくありません。"); //確認用
+          }
+        });
+      });
+    }
+  },
+  false
+);

--- a/app/controllers/cards_controller.rb
+++ b/app/controllers/cards_controller.rb
@@ -9,7 +9,7 @@ class CardsController < ApplicationController
   end
 
   def pay #payjpとCardのデータベース作成を実施します。
-    Payjp.api_key = "sk_test_4c3fb1f98f88fba0a8dcba0b"
+    Payjp.api_key = ENV["PAYJP_PRIVATE_KEY"]
     if params['payjp-token'].blank?
       redirect_to action: "new"
     else
@@ -57,7 +57,7 @@ class CardsController < ApplicationController
      # 購入した際の情報を元に引っ張ってくる
       card = current_user.credit_card
      # テーブル紐付けてるのでログインユーザーのクレジットカードを引っ張ってくる
-      Payjp.api_key = "sk_test_4c3fb1f98f88fba0a8dcba0b"
+      Payjp.api_key = ENV["PAYJP_PRIVATE_KEY"]
      # キーをセットする(環境変数においても良い)
       Payjp::Charge.create(
       amount: @product.price, #支払金額

--- a/app/controllers/cards_controller.rb
+++ b/app/controllers/cards_controller.rb
@@ -1,2 +1,81 @@
 class CardsController < ApplicationController
+
+  require "payjp"
+
+  def new
+    card = Card.where(user_id: current_user.id)
+    redirect_to action: "show" if card.exists?
+  end
+
+  def pay #payjpとCardのデータベース作成を実施します。
+    Payjp.api_key = "sk_test_4c3fb1f98f88fba0a8dcba0b"
+    if params['payjp-token'].blank?
+      redirect_to action: "new"
+    else
+      customer = Payjp::Customer.create(
+      description: '登録テスト', #なくてもOK
+      email: current_user.email, #なくてもOK
+      card: params['payjp-token'],
+      metadata: {user_id: current_user.id}
+      ) #念の為metadataにuser_idを入れましたがなくてもOK
+      @card = Card.new(user_id: current_user.id, customer_id: customer.id, card_id: customer.default_card)
+      if @card.save
+        redirect_to action: "show"
+      else
+        redirect_to action: "pay"
+      end
+    end
+  end
+
+  def delete #PayjpとCardデータベースを削除します
+    card = Card.where(user_id: current_user.id).first
+    if card.blank?
+    else
+      Payjp.api_key = "sk_test_4c3fb1f98f88fba0a8dcba0b"
+      customer = Payjp::Customer.retrieve(card.customer_id)
+      customer.delete
+      card.delete
+    end
+      redirect_to action: "new"
+  end
+
+  def show #Cardのデータpayjpに送り情報を取り出します
+    card = Card.where(user_id: current_user.id).first
+    if card.blank?
+      redirect_to action: "new" 
+    else
+      Payjp.api_key = "sk_test_4c3fb1f98f88fba0a8dcba0b"
+      customer = Payjp::Customer.retrieve(card.customer_id)
+      @default_card_information = customer.cards.retrieve(card.card_id)
+    end
+  end
+
+  def buy #クレジット購入
+    if card.blank?
+      redirect_to action: "new"
+      flash[:alert] = '購入にはクレジットカード登録が必要です'
+    else
+      @product = Product.find(params[:product_id])
+     # 購入した際の情報を元に引っ張ってくる
+      card = current_user.credit_card
+     # テーブル紐付けてるのでログインユーザーのクレジットカードを引っ張ってくる
+      Payjp.api_key = "sk_test_4c3fb1f98f88fba0a8dcba0b"
+     # キーをセットする(環境変数においても良い)
+      Payjp::Charge.create(
+      amount: @product.price, #支払金額
+      customer: card.customer_id, #顧客ID
+      currency: 'jpy', #日本円
+      )
+     # ↑商品の金額をamountへ、cardの顧客idをcustomerへ、currencyをjpyへ入れる
+      if @product.update(status: 1, buyer_id: current_user.id)
+        flash[:notice] = '購入しました。'
+        redirect_to controller: "products", action: 'show'
+      else
+        flash[:alert] = '購入に失敗しました。'
+        redirect_to controller: "products", action: 'show'
+      end
+     #↑この辺はこちら側のテーブル設計どうりに色々しています
+    end
+  end
+
 end

--- a/app/controllers/cards_controller.rb
+++ b/app/controllers/cards_controller.rb
@@ -38,30 +38,29 @@ class CardsController < ApplicationController
   end
 
   def show #Cardのデータpayjpに送り情報を取り出します
-    card = Card.where(user_id: current_user.id).first
-    if card.blank?
+    if @card.blank?
       redirect_to action: "new" 
     else
       Payjp.api_key = "sk_test_4c3fb1f98f88fba0a8dcba0b"
-      customer = Payjp::Customer.retrieve(card.customer_id)
-      @default_card_information = customer.cards.retrieve(card.card_id)
+      customer = Payjp::Customer.retrieve(@card.customer_id)
+      @default_card_information = customer.cards.retrieve(@card.card_id)
     end
   end
 
   def buy #クレジット購入
-    if card.blank?
+    if @card.blank?
       redirect_to action: "new"
       flash[:alert] = '購入にはクレジットカード登録が必要です'
     else
       @product = Product.find(params[:product_id])
      # 購入した際の情報を元に引っ張ってくる
-      card = current_user.credit_card
+      @card = current_user.credit_card
      # テーブル紐付けてるのでログインユーザーのクレジットカードを引っ張ってくる
       Payjp.api_key = ENV["PAYJP_PRIVATE_KEY"]
      # キーをセットする(環境変数においても良い)
       Payjp::Charge.create(
       amount: @product.price, #支払金額
-      customer: card.customer_id, #顧客ID
+      customer: @card.customer_id, #顧客ID
       currency: 'jpy', #日本円
       )
      # ↑商品の金額をamountへ、cardの顧客idをcustomerへ、currencyをjpyへ入れる

--- a/app/controllers/cards_controller.rb
+++ b/app/controllers/cards_controller.rb
@@ -1,4 +1,5 @@
 class CardsController < ApplicationController
+  before_action :set_card, only: [:delete, :show]
 
   require "payjp"
 
@@ -28,15 +29,12 @@ class CardsController < ApplicationController
   end
 
   def delete #PayjpとCardデータベースを削除します
-    card = Card.where(user_id: current_user.id).first
-    if card.blank?
-    else
-      Payjp.api_key = "sk_test_4c3fb1f98f88fba0a8dcba0b"
-      customer = Payjp::Customer.retrieve(card.customer_id)
+    if @card.present?
+      customer = Payjp::Customer.retrieve(@card.customer_id)
       customer.delete
-      card.delete
+      @card.delete
     end
-      redirect_to action: "new"
+      redirect_to cards_path
   end
 
   def show #Cardのデータpayjpに送り情報を取り出します
@@ -78,4 +76,8 @@ class CardsController < ApplicationController
     end
   end
 
+  private
+  def set_card
+    @card = Card.find_by(user_id: current_user.id)
+  end
 end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -76,7 +76,7 @@ class ProductsController < ApplicationController
     if @card.blank?
       flash.now[:alert] = 'カードを登録してください。'
     else
-      Payjp.api_key = "sk_test_4c3fb1f98f88fba0a8dcba0b"
+      Payjp.api_key = ENV["PAYJP_PRIVATE_KEY"]
       #保管した顧客IDでpayjpから情報取得
       customer = Payjp::Customer.retrieve(@card.customer_id)
       #保管したカードIDでpayjpから情報取得、カード情報表示のためインスタンス変数に代入
@@ -85,7 +85,7 @@ class ProductsController < ApplicationController
   end
 
   def pay
-    Payjp.api_key = "sk_test_4c3fb1f98f88fba0a8dcba0b"
+    Payjp.api_key = ENV["PAYJP_PRIVATE_KEY"]
     charge = Payjp::Charge.create(
     amount: @product.price,
     customer: @card.customer_id,
@@ -100,7 +100,7 @@ class ProductsController < ApplicationController
   end
 
   def done
-    Payjp.api_key = "sk_test_4c3fb1f98f88fba0a8dcba0b"
+    Payjp.api_key = ENV["PAYJP_PRIVATE_KEY"]
     #保管した顧客IDでpayjpから情報取得
     customer = Payjp::Customer.retrieve(@card.customer_id)
     #保管したカードIDでpayjpから情報取得、カード情報表示のためインスタンス変数に代入

--- a/app/views/cards/new.html.haml
+++ b/app/views/cards/new.html.haml
@@ -1,0 +1,60 @@
+= form_tag(pay_cards_path, method: :post, id: 'charge-form',  name: "inputForm", class: "cards-form") do
+  .cards_header
+    %h2.cards_title
+      カード情報入力
+    .cards_contents
+      %label カード番号
+      %br
+      = text_field_tag "number", "", class: "number", placeholder: "半角数字のみ" ,maxlength: "16", type: "text", id: "card_number"
+      %ul.cards-logo
+        %li
+          = image_tag asset_path("cards/visa.svg")
+        %li
+          = image_tag asset_path("cards/mc_vrt_pos.svg")
+        %li
+          = image_tag asset_path("cards/jcb.svg")
+        %li
+          = image_tag asset_path("cards/saison-card.svg")
+        %li
+          = image_tag asset_path("cards/amex.svg")
+        %li
+          = image_tag asset_path("cards/discover.svg")
+      %br
+      %label 有効期限
+      %br
+      %select#exp_month{name: "exp_month", type: "text"}
+        %option{value: ""} --
+        %option{value: "1"}01
+        %option{value: "2"}02
+        %option{value: "3"}03
+        %option{value: "4"}04
+        %option{value: "5"}05
+        %option{value: "6"}06
+        %option{value: "7"}07
+        %option{value: "8"}08
+        %option{value: "9"}09
+        %option{value: "10"}10
+        %option{value: "11"}11
+        %option{value: "12"}12
+      %span 月/
+      %select#exp_year{name: "exp_year", type: "text"}
+        %option{value: ""} --
+        %option{value: "2019"}19
+        %option{value: "2020"}20
+        %option{value: "2021"}21
+        %option{value: "2022"}22
+        %option{value: "2023"}23
+        %option{value: "2024"}24
+        %option{value: "2025"}25
+        %option{value: "2026"}26
+        %option{value: "2027"}27
+        %option{value: "2028"}28
+        %option{value: "2029"}29
+      %span 年
+      %br
+      %br
+      %label セキュリティコード
+      = text_field_tag "cvc", "", class: "cvc", placeholder: "カード背面3~4桁の番号", maxlength: "4", id: "cvc"
+      #card_token
+      %br
+      = submit_tag "追加する", id: "token_submit", class: "submit"

--- a/app/views/cards/show.html.haml
+++ b/app/views/cards/show.html.haml
@@ -1,0 +1,15 @@
+.cards-show
+  .cards-show__title
+    %h2 登録クレジットカード情報
+    %br
+    .cards-contents
+      %p
+        = "**** **** **** " + @default_card_information.last4
+      %br
+      %p
+        - exp_month = @default_card_information.exp_month.to_s
+        - exp_year = @default_card_information.exp_year.to_s.slice(2,3)
+        = exp_month + " / " + exp_year
+        = form_tag(delete_cards_path, method: :post, id: 'charge-form',  name: "inputForm") do
+          %input{ type: "hidden", name: "card_id", value: "" }
+          %button 削除する

--- a/app/views/products/done.html.haml
+++ b/app/views/products/done.html.haml
@@ -1,0 +1,50 @@
+-# 商品購入完了画面
+.purchase-done
+  .purchase-done__header
+    .purchase-done__header__logo
+  .purchase-done__main
+    .purchase-done__main__up
+      %h2 発送をお待ちください
+      %h3 出品者からの発送通知をお待ち下さい
+    .purchase-done__main__explanation
+      %h1 購入が完了しました
+    .purchase-done__main__box
+      .product 
+        .photo
+          = image_tag @product.images[0].src.url, size: '200x200'
+    .name
+      = "商品名 #{@product.name}"
+    .detail
+      .money
+        ="送料込み ¥#{@product.price}"
+    .purchase-done__main__delivery
+      .address
+        %ul.address--delivery
+          配送先
+        %li=@product.user.destination.post_code
+        %li="#{current_user.destination.prefecture} #{current_user.destination.city} #{current_user.destination.address}#{current_user.destination.building_name}"
+        %li="購入者 #{current_user.first_name} #{current_user.family_name} " 
+    .purchase-done__main__payment
+      .method
+        %ul.method--number
+          支払方法
+          %li
+            = "**** **** **** " + @default_card_information.last4
+          %li
+            - exp_month = @default_card_information.exp_month.to_s
+            - exp_year = @default_card_information.exp_year.to_s.slice(2,3)
+            = exp_month + " / " + exp_year
+    .purchase-done__main__return
+      .purchase-done__main__return__box
+        =link_to 'TOPページへ戻る',root_path, class:"return_btn"
+  .purchase-done__footer
+    %ul
+      %li
+        = link_to 'プライバシーポリシー', "#", class: "footer-text"
+      %li
+        = link_to 'FURIMA利用規約', "#", class: "footer-text"
+      %li
+        = link_to '特定商取引に関する表記', "#", class: "footer-text"
+    .products-exhibit__footer__logo
+      -# = link_to image_tag('logo.png', class: "products-exhibit__footer__logo__icon"),root_path
+      %p © FURIMA

--- a/app/views/products/purchase.html.haml
+++ b/app/views/products/purchase.html.haml
@@ -1,0 +1,57 @@
+.purchase-verification
+  .purchase-verification__header
+    .purchase-verification__header__logo
+  .purchase-verification__main
+    .purchase-verification__main__up
+      購入内容の確認
+    .purchase-verification__main__box
+      .product 
+        .photo
+          = image_tag @product.images[0].src.url, size: '200x200'
+        .name
+          = "商品名 #{@product.name}"
+      %ul.detail
+        %li.money="送料込み ¥#{@product.price}"
+    .purchase-verification__main__pay
+      .purchase-verification__main__pay__point
+        ポイントはありません
+      .purchase-verification__main__pay__money
+        .purchase-verification__main__pay__money--left
+          支払金額
+        .purchase-verification__main__pay__money--right
+          =" ¥#{@product.price}"
+      .purchase-verification__main__pay__decision
+        - if @default_card_information.blank?
+          .buy-btn 
+            支払い方法を追加してください。
+        - else
+          = form_tag(action: :pay, method: :post) do
+            %button.buy-btn 購入する
+    .purchase-verification__main__delivery
+      .address
+        %ul.address--delivery
+          配送先
+        %li=@product.user.destination.post_code
+        %li="#{current_user.destination.prefecture} #{current_user.destination.city} #{current_user.destination.address}#{current_user.destination.building_name}"
+        %li="購入者 #{current_user.first_name} #{current_user.family_name} " 
+        -# .address--change
+        -#   -# = link_to destination_user_path(current_user.id), class:"address--change--btn" do
+        -#   -#   変更する
+    .purchase-verification__main__payment
+      .method
+        %ul.method--number
+          支払方法
+        - if @default_card_information.blank?
+          .method--change
+            = link_to "クレジットカードを登録する",new_card_path(current_user.id),class: "method--change--btn"
+        - else
+          %li
+            = "**** **** **** " + @default_card_information.last4
+          %li
+            - exp_month = @default_card_information.exp_month.to_s
+            - exp_year = @default_card_information.exp_year.to_s.slice(2,3)
+            = exp_month + " / " + exp_year
+          .method--change
+            = link_to new_card_path(current_user.id), class:"method--change--btn" do
+              変更する
+  .purchase-verificati

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,9 @@ Rails.application.routes.draw do
       get 'search'
       get 'get_category_children', defaults: { format: 'json' }
       get 'get_category_grandchildren', defaults: { format: 'json' }
+      get 'purchase/:id'=> 'products#purchase', as: 'purchase'          #購入確認ページ
+      post 'pay/:id'=> 'products#pay', as: 'pay'                        #httpメソッドはpostなので注意
+      get 'done/:id'=> 'products#done', as: 'done'                      #購入完了ページ
     end
   end
   resources :destinations, only: [:index, :edit, :update]


### PR DESCRIPTION
# What
・Pay.jpにおける購入機能の実装
・カードの登録・確認・削除が可能
・商品を購入した際にPay.jpに履歴が反映される

# Why
・フリマアプリにおける商品購入機能は根幹機能であるため。

# Gyazo挙動
・カード登録、登録内容表示
https://gyazo.com/a80384aa4ab8ca1276ac762c810191db
・商品購入挙動
https://gyazo.com/1f9874d1afc5a69f01cfdb57c25c289a
・Pay.jpの購入履歴
https://gyazo.com/7d643133a9d8956b28cfed29a7d81684
・データベースにおけるbuyer_idの反映内容
https://gyazo.com/40a5579b4b63c07894007422f706d317


